### PR TITLE
Adding EOL note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Once approved, Cisco DevNet reviewers then create a release to publish through o
 
 The goal of these learning labs is to ensure a 'hands-on' learning approach rather than theory or instructions.
 
+> **Note**: The `mantl-app` and `mantl-101` labs are being removed due to product EOL.
+
 ## About these Learning Labs
 
 These labs teach how to:


### PR DESCRIPTION
Adding note about mantl EOL and lab removal to readme; this commit is also meant to help if we need to roll back to a previous version after removing the `mantl-app` and `mantl-101` labs.

Part 1 of addressing https://github.com/CiscoDevNet/learning-labs-issues/issues/103